### PR TITLE
Fix Clippy lint

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -28,10 +28,10 @@ where
     Ok(resp.response.accounts.account)
   }
 
-  pub async fn balance<'a>(
+  pub async fn balance(
     &self,
     account_id_key: &str,
-    balance_request: BalanceRequest<'a>,
+    balance_request: BalanceRequest<'_>,
     callbacks: impl CallbackProvider,
   ) -> Result<BalanceResponse> {
     let balance: serde_json::Value = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,12 @@ impl Memstore {
   }
 }
 
+impl Default for Memstore {
+  fn default() -> Self {
+    Memstore::new()
+  }
+}
+
 impl Store for Memstore {
   fn put(
     &self,
@@ -227,7 +233,7 @@ impl Store for Memstore {
   ) -> Result<()> {
     let mut data = self.data.lock().unwrap();
 
-    let svc_state = data.entry(namespace.into()).or_insert_with(|| HashMap::new());
+    let svc_state = data.entry(namespace.into()).or_insert_with(HashMap::new);
     svc_state.insert(key.into(), value.into());
     Ok(())
   }
@@ -246,7 +252,7 @@ impl Store for Memstore {
     Ok(
       data
         .get(namespace.as_ref())
-        .and_then(|r| r.get(key.as_ref()).map(|v| v.clone())),
+        .and_then(|r| r.get(key.as_ref()).cloned()),
     )
   }
 }


### PR DESCRIPTION
Fix the following issues identified by running ./cargo clippy:

```shell
    Checking etrade v0.2.0 (/Users/pstrawderman/dev/rs-etrade)
warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
  --> src/accounts.rs:31:3
   |
31 | /   pub async fn balance<'a>(
32 | |     &self,
33 | |     account_id_key: &str,
34 | |     balance_request: BalanceRequest<'a>,
35 | |     callbacks: impl CallbackProvider,
36 | |   ) -> Result<BalanceResponse> {
   | |______________________________^
   |
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

warning: you don't need to add `&` to both the expression and the patterns
   --> src/session.rs:119:5
    |
119 | /     match &self.mode {
120 | |       &Mode::Sandbox => SANDBOX_URL,
121 | |       &Mode::Live => LIVE_URL,
122 | |     }
    | |_____^
    |
    = note: `#[warn(clippy::match_ref_pats)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats
help: try
    |
119 |     match self.mode {
120 |       Mode::Sandbox => SANDBOX_URL,
121 |       Mode::Live => LIVE_URL,
    |

warning: you don't need to add `&` to both the expression and the patterns
   --> src/session.rs:126:5
    |
126 | /     match &self.mode {
127 | |       &Mode::Sandbox => SANDBOX_NAMESPACE,
128 | |       &Mode::Live => LIVE_NAMESPACE,
129 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats
help: try
    |
126 |     match self.mode {
127 |       Mode::Sandbox => SANDBOX_NAMESPACE,
128 |       Mode::Live => LIVE_NAMESPACE,
    |

warning: use of `ok_or` followed by a function call
   --> src/session.rs:142:23
    |
142 |       .and_then(|r| r.ok_or(anyhow!("secret {}@{} not found.", API_KEY, self.namespace())))?;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `ok_or_else(|| anyhow!("secret {}@{} not found.", API_KEY, self.namespace()))`
    |
    = note: `#[warn(clippy::or_fun_call)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: use of `ok_or` followed by a function call
   --> src/session.rs:146:23
    |
146 |       .and_then(|r| r.ok_or(anyhow!("secret {}@{} not found.", SECRET_KEY, self.namespace())))?;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `ok_or_else(|| anyhow!("secret {}@{} not found.", SECRET_KEY, self.namespace()))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: you don't need to add `&` to both the expression and the patterns
   --> src/session.rs:318:92
    |
318 |       let (bare_uri, full_uri, params): (&str, String, Option<BTreeSet<(String, String)>>) = match &method {
    |  ____________________________________________________________________________________________^
319 | |       &Method::GET => {
320 | |         let qs = serde_urlencoded::to_string(&input)?;
321 | |         if qs.is_empty() {
...   |
331 | |       _ => (&uri, uri.clone(), None),
332 | |     };
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats
help: try
    |
318 |     let (bare_uri, full_uri, params): (&str, String, Option<BTreeSet<(String, String)>>) = match method {
319 |       Method::GET => {
    |

warning: you don't need to add `&` to both the expression and the patterns
   --> src/session.rs:339:18
    |
339 |         Some(v) => match &method {
    |  __________________^
340 | |         &Method::GET => hyper::Body::empty(),
341 | |         _ => serde_json::to_vec(&v)?.into(),
342 | |       },
    | |_______^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats
help: try
    |
339 |       Some(v) => match method {
340 |         Method::GET => hyper::Body::empty(),
    |

warning: returning the result of a `let` binding from a block
   --> src/session.rs:426:5
    |
425 |     let res = hyper::body::to_bytes(resp.into_body()).await.unwrap().to_vec();
    |     -------------------------------------------------------------------------- unnecessary `let` binding
426 |     res
    |     ^^^
    |
    = note: `#[warn(clippy::let_and_return)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return
help: return the expression directly
    |
425 |     
426 |     hyper::body::to_bytes(resp.into_body()).await.unwrap().to_vec()
    |

warning: you should consider adding a `Default` implementation for `Memstore`
   --> src/lib.rs:214:3
    |
214 | /   pub fn new() -> Self {
215 | |     Memstore {
216 | |       data: Arc::new(Mutex::new(HashMap::new())),
217 | |     }
218 | |   }
    | |___^
    |
    = note: `#[warn(clippy::new_without_default)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
    |
213 | impl Default for Memstore {
214 |     fn default() -> Self {
215 |         Self::new()
216 |     }
217 | }
    |

warning: redundant closure found
   --> src/lib.rs:230:65
    |
230 |     let svc_state = data.entry(namespace.into()).or_insert_with(|| HashMap::new());
    |                                                                 ^^^^^^^^^^^^^^^^^ help: remove closure as shown: `HashMap::new`
    |
    = note: `#[warn(clippy::redundant_closure)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure

warning: you are using an explicit closure for cloning elements
   --> src/lib.rs:249:23
    |
249 |         .and_then(|r| r.get(key.as_ref()).map(|v| v.clone())),
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `r.get(key.as_ref()).cloned()`
    |
    = note: `#[warn(clippy::map_clone)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone

warning: 11 warnings emitted
```